### PR TITLE
feat: make authorized user uid to be message author identifier (userI…

### DIFF
--- a/src/components/MessagesWindow/MessagesWindow.tsx
+++ b/src/components/MessagesWindow/MessagesWindow.tsx
@@ -32,12 +32,12 @@ export const MessagesWindow: FC = () => {
   const onSendMessage = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (chatId) {
+    if (chatId && user) {
       dispatch(
         sendMessageWithBotReply({
           chatId,
           message: {
-            author: userName,
+            userId: user?.uid,
             text: messageSendingFormInputValue,
           },
         })

--- a/src/components/MessagesWindow/components/MessageList/components/MessageItem/MessageItem.test.tsx
+++ b/src/components/MessagesWindow/components/MessageList/components/MessageItem/MessageItem.test.tsx
@@ -25,7 +25,7 @@ describe('Message', () => {
 
   it('should have system message classname applied for bot message', () => {
     const message: Message = {
-      author: Authors.BOT,
+      userId: Authors.BOT,
       text: 'test',
     };
 

--- a/src/components/MessagesWindow/components/MessageList/components/MessageItem/MessageItem.tsx
+++ b/src/components/MessagesWindow/components/MessageList/components/MessageItem/MessageItem.tsx
@@ -19,7 +19,7 @@ export const MessageItem: FC<MessageItemProps> = ({
   let isBotMessage = false;
   let MessageListItemClasses = classNames(style[`message__type-${variant}`]);
 
-  if (message.author === AUTHORS.bot) {
+  if (message.userId === AUTHORS.bot) {
     isBotMessage = !isBotMessage;
     MessageListItemClasses += ` ${style['message__system-background']}`;
   } else {
@@ -34,7 +34,7 @@ export const MessageItem: FC<MessageItemProps> = ({
     >
       {message.text}
       <span className={style['message__author-sign']}>
-        {isBotMessage ? message.author : userName}
+        {isBotMessage ? message.userId : userName}
       </span>
     </MUIStyledMessageListItem>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,15 +29,15 @@ export const DUMMY_CONTENT = {
   messages: [
     {
       text: 'placerat duis ultricies lacus sed turpis tincidunt id aliquet risus',
-      author: AUTHORS.user,
+      userId: AUTHORS.user,
     },
     {
       text: 'et molestie ac feugiat sed lectus vestibulum mattis ullamcorper velit',
-      author: AUTHORS.user,
+      userId: AUTHORS.user,
     },
     {
       text: 'felis eget velit aliquet sagittis id consectetur purus ut faucibus',
-      author: AUTHORS.user,
+      userId: AUTHORS.user,
     },
   ] as Message[],
 };

--- a/src/default-types.ts
+++ b/src/default-types.ts
@@ -20,12 +20,12 @@ export interface FirebaseChats {
 
 export interface Message {
   text: string;
-  author: string;
+  userId: string;
 }
 
 export type MessageItemWithId = { id: string } & Message;
 
-export type FirebaseMessage = [string, { text: string; author: string }];
+export type FirebaseMessage = [string, { text: string; userId: string }];
 
 export interface Chat {
   messages?: MessageItemWithId[];

--- a/src/store/chats/slice.ts
+++ b/src/store/chats/slice.ts
@@ -37,7 +37,7 @@ const parseFirebaseMessages = (firebaseMessages: {
     return Object.entries(firebaseMessages).map((message: FirebaseMessage) => ({
       id: message[0],
       text: message[1].text,
-      author: message[1].author,
+      userId: message[1].userId,
     }));
   }
 

--- a/src/store/sagas.ts
+++ b/src/store/sagas.ts
@@ -24,12 +24,12 @@ const asyncAddMessageWithBotReply = async (
 
   store.dispatch(addMessage(chatId, message));
 
-  if (message.author !== Authors.BOT) {
+  if (message.userId !== Authors.BOT) {
     timeout = setTimeout(
       () =>
         store.dispatch(
           addMessage(chatId, {
-            author: Authors.BOT,
+            userId: Authors.BOT,
             text: 'Bot response',
           })
         ),


### PR DESCRIPTION
…d). change 'author' property to 'userId' at firebase messages parsing (store/chats/slice.ts). change message identifier usage during conditioning from 'author' to 'userId' (asyncAddMessageWithBotReply function in store/sagas.ts). add user value check before message sending is initialized and change message identifier property (to 'userId') in message sending function arguments (MessagesWindows.tsx). change message property that is checked during bot message identification (MessageItem.tsx). change MessageItem.test.tsx so that tests use correct message identifier property ('userId'). change Message and FirebaseMessage interfaces — 'userId' instead of 'author' (default-types.ts). change DUMMY_CONTENT constant so that it satisfies the Message interface (constants.ts).